### PR TITLE
Modify Accessibilities of some methods

### DIFF
--- a/src/Sender.php
+++ b/src/Sender.php
@@ -160,15 +160,15 @@ class Sender
     }
 
     /**
-     * @param array|string $to
+     * @param array|string $sendTo
      * @param array $content
      * @return $this|mixed
      */
-    protected function sendMessage($to, $content)
+    protected function sendMessage($sendTo, $content)
     {
         $this->response = $this->guzzleClient->request('POST', self::ENDPOINT_EVENTS, [
             'headers' => $this->createRequestHeaderArray(),
-            'body' => $this->createRequestBodyJson($to, $content),
+            'body' => $this->createRequestBodyJson($sendTo, $content),
         ]);
         return $this;
     }
@@ -187,17 +187,17 @@ class Sender
     }
 
     /**
-     * @param array|string $to
+     * @param array|string $sendTo
      * @param array $content
      * @return string json
      */
-    protected function createRequestBodyJson($to, $content)
+    protected function createRequestBodyJson($sendTo, $content)
     {
-        if (!is_array($to)) {
-            $to = [$to];
+        if (!is_array($sendTo)) {
+            $sendTo = [$sendTo];
         }
         return json_encode([
-                'to' => $to,
+                'to' => $sendTo,
                 'toChannel' => self::TO_CHANNEL,
                 'eventType' => self::EVENT_TYPE,
                 'content' => $content,

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -164,7 +164,7 @@ class Sender
      * @param array $content
      * @return $this|mixed
      */
-    public function sendMessage($to, $content)
+    protected function sendMessage($to, $content)
     {
         $this->response = $this->guzzleClient->request('POST', self::ENDPOINT_EVENTS, [
             'headers' => $this->createRequestHeaderArray(),

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -176,7 +176,7 @@ class Sender
     /**
      * @return array
      */
-    private function createRequestHeaderArray()
+    protected function createRequestHeaderArray()
     {
         return [
             'Content-Type' => 'application/json; charset=UTF-8',
@@ -191,7 +191,7 @@ class Sender
      * @param array $content
      * @return string json
      */
-    private function createRequestBodyJson($to, $content)
+    protected function createRequestBodyJson($to, $content)
     {
         if (!is_array($to)) {
             $to = [$to];


### PR DESCRIPTION
- Sender::sendMessage() become protected (before: public)
- Sender::createRequestHeaderArray() become protected (before: private)
- Sender::createRequestBodyJson() become protected (before: private)
